### PR TITLE
Bugfix/digest

### DIFF
--- a/README.md
+++ b/README.md
@@ -77,6 +77,7 @@ config = XMPP::Config.new(
   sasl_auth_order: [XMPP::AuthMechanism::SCRAM_SHA_512, XMPP::AuthMechanism::SCRAM_SHA_256,
                     XMPP::AuthMechanism::SCRAM_SHA_1, XMPP::AuthMechanism::DIGEST_MD5,
                     XMPP::AuthMechanism::PLAIN, XMPP::AuthMechanism::ANONYMOUS]
+)
 
 router = XMPP::Router.new
 

--- a/src/xmpp/auth/scram-sha.cr
+++ b/src/xmpp/auth/scram-sha.cr
@@ -77,7 +77,7 @@ module XMPP
 
       # stored_key = OpenSSL::SHA1.hash(client_key.to_unsafe, LibC::SizeT.new(client_key.bytesize))
       hasher.update(client_key)
-      stored_key = hasher.digest
+      stored_key = hasher.final
 
       auth_msg = "#{initial_msg},#{server_resp},#{bare_msg}"
       client_sig = OpenSSL::HMAC.digest(algorithm: algorithm, key: stored_key, data: auth_msg)


### PR DESCRIPTION
A [recent refactor of the Digest classes](https://github.com/crystal-lang/crystal/pull/9864) means that the [deprecated digest method](https://crystal-lang.org/api/0.35.1/Digest/Base.html#digest:Bytes-instance-method) has been removed from crystal 0.36, in favor of the final method. 

This PR changes the method call accordingly,  fixing compilation errors seen, for example, compiling the usage example in the project README. It also corrects a syntax error in the usage example.