### PR TITLE
Reduce CPU usage of wait group by blocking

### DIFF
--- a/spec/wait_group_spec.cr
+++ b/spec/wait_group_spec.cr
@@ -1,0 +1,50 @@
+require "./spec_helper"
+
+module XMPP
+  describe WaitGroup do
+
+    it "Should not block on creation" do
+      wg = WaitGroup.new
+      wg.wait
+    end
+
+    it "Should block whilst not done" do
+      wg = WaitGroup.new
+      wg.add.should eq 1
+      progress = Atomic(Int32).new(0)
+      spawn { progress.add(1); wg.wait; progress.add(1) }
+      sleep 5.milliseconds
+      # Should get to wait but not beyond it
+      progress.get.should eq 1
+      wg.done.should eq 0
+      while progress.get != 2
+         sleep 1.milliseconds
+      end
+    end
+
+    it "Should support multiple waiters" do
+      wg = WaitGroup.new
+      wg.add.should eq 1
+      unblocked = Atomic(Int32).new(0)
+      nwaiters = 10
+      (1..nwaiters).each { spawn { wg.wait; unblocked.add(1) } }
+      sleep 5.milliseconds
+      unblocked.get.should eq 0
+      wg.done.should eq 0
+      while unblocked.get != nwaiters
+        sleep 1.milliseconds
+      end
+    end
+
+    it "Won't block again after done" do
+      wg = WaitGroup.new
+      wg.add
+      wg.done
+      wg.done?.should be_true
+      wg.wait
+      wg.add
+      wg.done?.should be_true
+    end
+
+  end
+end


### PR DESCRIPTION
Whilst running some code using cr-xmpp on my server, I noticed that the process was consistently consuming a few percent CPU when idle. On investigation I found that a thread was continuously spinning in WaitGroup's wait method, polling on a very short timeout. I've made some modifications to WaitGroup in this PR that adds a channel so that wait can block until notified that the counter had reached zero, rather than poll for it. It's been running on my server for a few days without any issues. There's also a handful of tests to sanity check the behavior. There's a slight change in semantics in that once add is called and later the counter finally hits zero, wait won't ever block again, but I don't think that's a problem based on the way it's currently used.