### PR TITLE
add raw_node to PubSub Item for downstream parsers

### DIFF
--- a/src/xmpp/stanza/pubsub.cr
+++ b/src/xmpp/stanza/pubsub.cr
@@ -328,10 +328,12 @@ module XMPP::Stanza
     property id : String = ""
     property tune : Tune? = nil
     property mood : Mood? = nil
+    property raw_node : XML::Node? = nil
 
     def self.new(node : XML::Node)
       raise "Invalid #{@@xml_name} node: #{node.name}" unless node.name == @@xml_name
       pr = new()
+      pr.raw_node = node
       node.attributes.each do |attr|
         case attr.name
         when "id" then pr.id = attr.children[0].content


### PR DESCRIPTION
Hey @naqvis, :wave: 

some payloads carry XML the stanza parser doesn't model (OMEMO bundles under PEP items being the obvious one).
Thus we should keep the raw XML::Node reference on parse so callers can walk children without re-parsing the whole stanza.