### PR TITLE
stanzaa: XEP-0380 EME marker

### DIFF
--- a/spec/stanza/message/eme_spec.cr
+++ b/spec/stanza/message/eme_spec.cr
@@ -1,0 +1,43 @@
+require "../../spec_helper"
+
+module XMPP::Stanza
+  describe ExplicitMessageEncryption do
+    it "parses an EME marker (XEP-0380)" do
+      xml = <<-XML
+          <message from='alex@switzerland.ch' to='ali@wherever-you-are.org' type='chat'>
+            <body>This message is encrypted.</body>
+            <encryption xmlns='urn:xmpp:eme:0'
+                        namespace='eu.siacs.conversations.axolotl'
+                        name='OMEMO'/>
+          </message>
+          XML
+
+      msg = Message.new xml
+      fail "no extension parsed" if msg.extensions.empty?
+
+      eme = msg.extensions.find { |e| e.is_a?(ExplicitMessageEncryption) }
+      fail "no EME extension found" unless eme.is_a?(ExplicitMessageEncryption)
+      eme.namespace.should eq("eu.siacs.conversations.axolotl")
+      eme.name_attr.should eq("OMEMO")
+    end
+
+    it "serialises with namespace and name attrs" do
+      ext = ExplicitMessageEncryption.new
+      ext.namespace = ExplicitMessageEncryption::OMEMO_LEGACY_NS
+      ext.name_attr = "OMEMO"
+
+      out = XML.build { |xml| ext.to_xml(xml) }
+      out.should contain(%(xmlns="urn:xmpp:eme:0"))
+      out.should contain(%(namespace="eu.siacs.conversations.axolotl"))
+      out.should contain(%(name="OMEMO"))
+    end
+
+    it "omits optional name attr when blank" do
+      ext = ExplicitMessageEncryption.new
+      ext.namespace = ExplicitMessageEncryption::OMEMO_V2_NS
+
+      out = XML.build { |xml| ext.to_xml(xml) }
+      out.should_not contain("name=")
+    end
+  end
+end

--- a/src/xmpp/stanza/message/eme.cr
+++ b/src/xmpp/stanza/message/eme.cr
@@ -1,0 +1,58 @@
+require "../registry"
+require "../../xmpp"
+
+module XMPP::Stanza
+  MSG_EME_NS = "urn:xmpp:eme:0"
+
+  # XEP-0380 Explicit Message Encryption.
+  # https://xmpp.org/extensions/xep-0380.html
+  #
+  # A small marker that tells receiving clients what kind of
+  # encrypted payload is inside the stanza, without having to
+  # peek at the actual encryption extension. Without it,
+  # Conversations and other clients can fail to surface an
+  # encrypted message at all (no notification, no chat bubble)
+  # when they cannot decrypt the payload, they don't even know
+  # there is anything to display.
+  #
+  # well-known namespaces (from the XEP registry):
+  #   urn:xmpp:omemo:2       OMEMO 2
+  #   eu.siacs.conversations.axolotl  OMEMO legacy
+  #   urn:xmpp:openpgp:0     OpenPGP for XMPP (OX)
+  #   jabber:x:encrypted     legacy OpenPGP (XEP-0027)
+  class ExplicitMessageEncryption < MsgExtension
+    OMEMO_LEGACY_NS = "eu.siacs.conversations.axolotl"
+    OMEMO_V2_NS     = "urn:xmpp:omemo:2"
+
+    class_getter xml_name : XMLName = XMLName.new(MSG_EME_NS, "encryption")
+    property namespace : String = ""
+    property name_attr : String = ""
+
+    def self.new(node : XML::Node)
+      raise "Invalid node(#{node.name}, expecting #{@@xml_name})" unless (node.namespace.try &.href == @@xml_name.space) &&
+                                                                          (node.name == @@xml_name.local)
+      pr = new()
+      node.attributes.each do |attr|
+        case attr.name
+        when "namespace" then pr.namespace = attr.children[0].content
+        when "name"      then pr.name_attr = attr.children[0].content
+        end
+      end
+      pr
+    end
+
+    def to_xml(xml : XML::Builder)
+      dict = Hash(String, String).new
+      dict["xmlns"] = @@xml_name.space
+      dict["namespace"] = namespace unless namespace.blank?
+      dict["name"] = name_attr unless name_attr.blank?
+      xml.element(@@xml_name.local, dict)
+    end
+
+    def name : String
+      @@xml_name.local
+    end
+  end
+
+  Registry.map_extension(PacketType::Message, XMLName.new(MSG_EME_NS, "encryption"), ExplicitMessageEncryption)
+end


### PR DESCRIPTION
A tiny hint element that tells the receiver what kind of encrypted payload is inside the stanza (OMEMO, OMEMO 2, OpenPGP, legacy PGP, ...) without having to peek at the encryption extension
itself.

Without it, Conversations and other clients can silently drop an encrypted message when they can't decrypt the payload. No notification, no chat bubble, the user never learns anything arrived.